### PR TITLE
Update QlCrossCompiler.lyx

### DIFF
--- a/QlCrossCompiler.lyx
+++ b/QlCrossCompiler.lyx
@@ -1691,7 +1691,7 @@ vasm
 \emph on
 vlink
 \emph default
- version 0.16c are required.
+ version 0.16h are required.
 \end_layout
 
 \begin_layout Standard


### PR DESCRIPTION
Update required vlink version from 0.16c to 0.16h.